### PR TITLE
chore: add crate publish metadata

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ name = "sqlc-gen-sqlx"
 version = "0.0.0"
 edition = "2024"
 license = "MIT OR Apache-2.0"
+description = "A sqlc plugin that generates type-safe sqlx Rust code from SQL queries."
+repository = "https://github.com/mathematic-inc/sqlc-gen-sqlx"
 
 [[bin]]
 name = "sqlc-gen-sqlx"


### PR DESCRIPTION
## What changed
Adds the missing crate metadata required by crates.io publishing.

## Why
`cargo publish` was blocked because `Cargo.toml` did not include a package description. Adding description and repository metadata makes the crate publishable and improves the crate page.

## Validation
Published `sqlc-gen-sqlx v0.0.0` successfully to crates.io after this change.