### PR TITLE
chore: add trusted-publisher crates.io release job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,3 +125,33 @@ jobs:
             dist/sqlc-gen-sqlx.wasm \
             dist/sqlc-gen-sqlx.wasm.sha256 \
             --clobber
+
+  publish-crate:
+    name: Publish to crates.io
+    needs: publish-release
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
+        with:
+          toolchain: stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
+
+      - name: Authenticate with crates.io
+        id: crates-io-auth
+        uses: rust-lang/crates-io-auth-action@bbd81622f20ce9e2dd9622e3218b975523e45bbe # v1.0.4
+
+      - name: Publish crate
+        run: cargo publish --locked
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}


### PR DESCRIPTION
## What changed
Adds a separate crates.io publish job to the tag-driven release workflow while keeping the existing WASM GitHub release flow intact.

## Why
We want crates.io publishing to follow the `unfmt` trusted-publisher pattern instead of using a long-lived registry token.

## Impact
Tag releases will still verify, build, and upload WASM assets, then run a dedicated crates.io publish job authenticated through GitHub OIDC and `rust-lang/crates-io-auth-action`.

## Validation
- Reviewed the workflow diff for job ordering and permissions
- Ran `cargo publish --dry-run --locked --allow-dirty` successfully