### PR TITLE
feat: add Queries::into_inner

### DIFF
--- a/examples/advanced-types/src/queries.rs
+++ b/examples/advanced-types/src/queries.rs
@@ -89,6 +89,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn get_event(&mut self, id: i64) -> Result<GetEventRow, sqlx::Error> {

--- a/examples/basic/src/queries.rs
+++ b/examples/basic/src/queries.rs
@@ -102,6 +102,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn get_author(&mut self, id: i64) -> Result<GetAuthorRow, sqlx::Error> {

--- a/examples/batch/src/queries.rs
+++ b/examples/batch/src/queries.rs
@@ -81,6 +81,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub fn batch_get_author<'a, I>(

--- a/examples/enums/src/queries.rs
+++ b/examples/enums/src/queries.rs
@@ -103,6 +103,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn get_user(&mut self, id: i64) -> Result<GetUserRow, sqlx::Error> {

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -97,6 +97,10 @@ pub fn generate(request: &GenerateRequestView<'_>, config: &Config) -> Result<St
             pub fn new(db: E) -> Self {
                 Self { db }
             }
+
+            pub fn into_inner(self) -> E {
+                self.db
+            }
         }
     });
 

--- a/tests/snapshots/codegen__batch_dynamic_slice_param.snap
+++ b/tests/snapshots/codegen__batch_dynamic_slice_param.snap
@@ -61,6 +61,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub fn batch_list_authors_by_dynamic_ids<'a, I>(

--- a/tests/snapshots/codegen__batchexec.snap
+++ b/tests/snapshots/codegen__batchexec.snap
@@ -55,6 +55,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub fn batch_delete_author<'a, I>(

--- a/tests/snapshots/codegen__batchmany.snap
+++ b/tests/snapshots/codegen__batchmany.snap
@@ -61,6 +61,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub fn batch_list_authors<'a, I>(

--- a/tests/snapshots/codegen__batchone.snap
+++ b/tests/snapshots/codegen__batchone.snap
@@ -61,6 +61,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub fn batch_get_author<'a, I>(

--- a/tests/snapshots/codegen__composite_types.snap
+++ b/tests/snapshots/codegen__composite_types.snap
@@ -61,4 +61,7 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }

--- a/tests/snapshots/codegen__copyfrom.snap
+++ b/tests/snapshots/codegen__copyfrom.snap
@@ -61,6 +61,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn copy_authors<I>(&mut self, items: I) -> Result<u64, sqlx::Error>

--- a/tests/snapshots/codegen__dynamic_slice_param.snap
+++ b/tests/snapshots/codegen__dynamic_slice_param.snap
@@ -61,6 +61,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn list_authors_by_dynamic_ids(

--- a/tests/snapshots/codegen__embed.snap
+++ b/tests/snapshots/codegen__embed.snap
@@ -66,6 +66,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn get_author_embed(

--- a/tests/snapshots/codegen__enum_types.snap
+++ b/tests/snapshots/codegen__enum_types.snap
@@ -69,6 +69,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn get_user_status(

--- a/tests/snapshots/codegen__exec.snap
+++ b/tests/snapshots/codegen__exec.snap
@@ -55,6 +55,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn delete_author(&mut self, id: i64) -> Result<(), sqlx::Error> {

--- a/tests/snapshots/codegen__execlastid.snap
+++ b/tests/snapshots/codegen__execlastid.snap
@@ -55,6 +55,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn create_author(&mut self, name: String) -> Result<i64, sqlx::Error> {

--- a/tests/snapshots/codegen__execresult.snap
+++ b/tests/snapshots/codegen__execresult.snap
@@ -55,6 +55,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn delete_author_result(

--- a/tests/snapshots/codegen__execrows.snap
+++ b/tests/snapshots/codegen__execrows.snap
@@ -55,6 +55,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn delete_author_rows(&mut self, id: i64) -> Result<u64, sqlx::Error> {

--- a/tests/snapshots/codegen__many.snap
+++ b/tests/snapshots/codegen__many.snap
@@ -61,6 +61,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn list_authors(&mut self) -> Result<Vec<ListAuthorsRow>, sqlx::Error> {

--- a/tests/snapshots/codegen__multidimensional_array_types.snap
+++ b/tests/snapshots/codegen__multidimensional_array_types.snap
@@ -59,6 +59,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn get_matrix(

--- a/tests/snapshots/codegen__named_params.snap
+++ b/tests/snapshots/codegen__named_params.snap
@@ -60,6 +60,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn update_author_named_params(

--- a/tests/snapshots/codegen__nullable_named_param.snap
+++ b/tests/snapshots/codegen__nullable_named_param.snap
@@ -61,6 +61,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn list_authors_by_optional_bio(

--- a/tests/snapshots/codegen__one.snap
+++ b/tests/snapshots/codegen__one.snap
@@ -61,6 +61,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn get_author(&mut self, id: i64) -> Result<GetAuthorRow, sqlx::Error> {

--- a/tests/snapshots/codegen__range_types.snap
+++ b/tests/snapshots/codegen__range_types.snap
@@ -61,6 +61,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn get_event_window(

--- a/tests/snapshots/codegen__slice_param.snap
+++ b/tests/snapshots/codegen__slice_param.snap
@@ -61,6 +61,9 @@ impl<E> Queries<E> {
     pub fn new(db: E) -> Self {
         Self { db }
     }
+    pub fn into_inner(self) -> E {
+        self.db
+    }
 }
 impl<E: AsExecutor> Queries<E> {
     pub async fn list_authors_by_ids(


### PR DESCRIPTION
## Summary
- Adds `into_inner()` to `Queries<E>` to recover the wrapped executor after use.

## Test plan
- [x] snapshots + examples regenerated
- [x] fmt, clippy, workspace tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)