### PR TITLE
fix: omit trailing next_placeholder increment after last param

### DIFF
--- a/src/codegen/query.rs
+++ b/src/codegen/query.rs
@@ -193,11 +193,19 @@ pub(crate) fn dynamic_sql_setup(
         });
     }
 
-    tokens.push(quote! {
-        let mut next_placeholder = 1usize;
-    });
-
-    for param in ordered_params(params) {
+    let ordered = ordered_params(params);
+    if ordered.len() > 1 {
+        tokens.push(quote! {
+            let mut next_placeholder = 1usize;
+        });
+    } else if ordered.len() == 1 {
+        tokens.push(quote! {
+            let next_placeholder = 1usize;
+        });
+    }
+    let last_idx = ordered.len().saturating_sub(1);
+    for (idx, param) in ordered.iter().enumerate() {
+        let is_last = idx == last_idx;
         let placeholder_ident = format_ident!("placeholder_{}", param.number as usize);
         tokens.push(quote! {
             let #placeholder_ident = next_placeholder;
@@ -208,6 +216,11 @@ pub(crate) fn dynamic_sql_setup(
             let marker = format!("/*SLICE:{}*/?", param.source_name);
             let numbered_marker = format!("/*SLICE:{}*/${}", param.source_name, param.number);
             let bare_placeholder = format!("${}", param.number);
+            let advance = if is_last {
+                quote! {}
+            } else {
+                quote! { next_placeholder += slice_len; }
+            };
             tokens.push(quote! {
                 let slice_len = (#value_expr).len();
                 let replacement = if slice_len == 0 {
@@ -227,13 +240,18 @@ pub(crate) fn dynamic_sql_setup(
                         sql = sql.replace(#bare_placeholder, &replacement);
                     }
                 }
-                next_placeholder += slice_len;
+                #advance
             });
         } else {
             let temporary = format!("__SQLC_PARAM_{}__", param.number);
+            let advance = if is_last {
+                quote! {}
+            } else {
+                quote! { next_placeholder += 1; }
+            };
             tokens.push(quote! {
                 sql = sql.replace(#temporary, &format!("${}", #placeholder_ident));
-                next_placeholder += 1;
+                #advance
             });
         }
     }

--- a/tests/snapshots/codegen__batch_dynamic_slice_param.snap
+++ b/tests/snapshots/codegen__batch_dynamic_slice_param.snap
@@ -79,7 +79,7 @@ impl<E: AsExecutor> Queries<E> {
                 };
                 let ids = item;
                 let mut sql = BATCH_LIST_AUTHORS_BY_DYNAMIC_IDS.to_string();
-                let mut next_placeholder = 1usize;
+                let next_placeholder = 1usize;
                 let placeholder_1 = next_placeholder;
                 let slice_len = (ids).len();
                 let replacement = if slice_len == 0 {
@@ -99,7 +99,6 @@ impl<E: AsExecutor> Queries<E> {
                         sql = sql.replace("$1", &replacement);
                     }
                 }
-                next_placeholder += slice_len;
                 let mut query = sqlx::query_as::<
                     _,
                     BatchListAuthorsByDynamicIdsRow,

--- a/tests/snapshots/codegen__dynamic_slice_param.snap
+++ b/tests/snapshots/codegen__dynamic_slice_param.snap
@@ -65,7 +65,7 @@ impl<E: AsExecutor> Queries<E> {
         ids: Vec<i64>,
     ) -> Result<Vec<ListAuthorsByDynamicIdsRow>, sqlx::Error> {
         let mut sql = LIST_AUTHORS_BY_DYNAMIC_IDS.to_string();
-        let mut next_placeholder = 1usize;
+        let next_placeholder = 1usize;
         let placeholder_1 = next_placeholder;
         let slice_len = (ids).len();
         let replacement = if slice_len == 0 {
@@ -85,7 +85,6 @@ impl<E: AsExecutor> Queries<E> {
                 sql = sql.replace("$1", &replacement);
             }
         }
-        next_placeholder += slice_len;
         let mut query = sqlx::query_as::<_, ListAuthorsByDynamicIdsRow>(&sql);
         for value in ids {
             query = query.bind(value);


### PR DESCRIPTION
## Summary
- Generated slice-replacement code ended with `next_placeholder += slice_len` (or `+= 1`) even for the final param, producing a dead store that trips `unused_assignments` in downstream crates.
- Emit the increment only when a later param will consume it; drop `mut` when there is a single param; skip the declaration entirely for zero-param queries.
- Snapshots updated.

## Test plan
- [x] `cargo test` (snapshot + postgres integration)