### PR TITLE
feat: export generated SQL constants

### DIFF
--- a/src/codegen/query.rs
+++ b/src/codegen/query.rs
@@ -320,7 +320,7 @@ pub(crate) fn dynamic_bind_statements(
 pub(crate) fn sql_const(query_name: &str, sql: &str) -> (TokenStream, proc_macro2::Ident) {
     let const_name = format_ident!("{}", to_snake_case(query_name).to_uppercase());
     let tokens = quote! {
-        const #const_name: &str = #sql;
+        pub const #const_name: &str = #sql;
     };
     (tokens, const_name)
 }

--- a/tests/snapshots/codegen__batch_dynamic_slice_param.snap
+++ b/tests/snapshots/codegen__batch_dynamic_slice_param.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const BATCH_LIST_AUTHORS_BY_DYNAMIC_IDS: &str = "SELECT id, name, bio FROM authors WHERE id IN ($1)";
+pub const BATCH_LIST_AUTHORS_BY_DYNAMIC_IDS: &str = "SELECT id, name, bio FROM authors WHERE id IN ($1)";
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct BatchListAuthorsByDynamicIdsRow {
     pub id: i64,

--- a/tests/snapshots/codegen__batchexec.snap
+++ b/tests/snapshots/codegen__batchexec.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const BATCH_DELETE_AUTHOR: &str = "DELETE FROM authors WHERE id = $1";
+pub const BATCH_DELETE_AUTHOR: &str = "DELETE FROM authors WHERE id = $1";
 pub fn batch_delete_author<'a, E, I>(
     db: E,
     items: I,

--- a/tests/snapshots/codegen__batchmany.snap
+++ b/tests/snapshots/codegen__batchmany.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const BATCH_LIST_AUTHORS: &str = "SELECT id, name, bio FROM authors WHERE bio LIKE $1";
+pub const BATCH_LIST_AUTHORS: &str = "SELECT id, name, bio FROM authors WHERE bio LIKE $1";
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct BatchListAuthorsRow {
     pub id: i64,

--- a/tests/snapshots/codegen__batchone.snap
+++ b/tests/snapshots/codegen__batchone.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const BATCH_GET_AUTHOR: &str = "SELECT id, name, bio FROM authors WHERE id = $1";
+pub const BATCH_GET_AUTHOR: &str = "SELECT id, name, bio FROM authors WHERE id = $1";
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct BatchGetAuthorRow {
     pub id: i64,

--- a/tests/snapshots/codegen__borrowed_array_param.snap
+++ b/tests/snapshots/codegen__borrowed_array_param.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const LIST_BY_TAGS: &str = "DELETE FROM authors WHERE name = ANY($1)";
+pub const LIST_BY_TAGS: &str = "DELETE FROM authors WHERE name = ANY($1)";
 pub async fn list_by_tags<E: AsExecutor>(
     mut db: E,
     tags: &[String],

--- a/tests/snapshots/codegen__borrowed_batchexec.snap
+++ b/tests/snapshots/codegen__borrowed_batchexec.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const BATCH_DELETE_BY_NAME: &str = "DELETE FROM authors WHERE name = $1";
+pub const BATCH_DELETE_BY_NAME: &str = "DELETE FROM authors WHERE name = $1";
 pub fn batch_delete_by_name<'a, E, I>(
     db: E,
     items: I,

--- a/tests/snapshots/codegen__borrowed_batchexec_struct.snap
+++ b/tests/snapshots/codegen__borrowed_batchexec_struct.snap
@@ -49,7 +49,7 @@ pub struct BatchUpdateAuthorParams<'a> {
     pub bio: Option<&'a str>,
     pub id: i64,
 }
-const BATCH_UPDATE_AUTHOR: &str = "UPDATE authors SET name = $1, bio = $2 WHERE id = $3";
+pub const BATCH_UPDATE_AUTHOR: &str = "UPDATE authors SET name = $1, bio = $2 WHERE id = $3";
 pub fn batch_update_author<'a, E, I>(
     db: E,
     items: I,

--- a/tests/snapshots/codegen__borrowed_copyfrom.snap
+++ b/tests/snapshots/codegen__borrowed_copyfrom.snap
@@ -48,7 +48,7 @@ pub struct CopyAuthorsParams<'a> {
     pub name: &'a str,
     pub bio: Option<&'a str>,
 }
-const COPY_AUTHORS: &str = "INSERT INTO authors (name, bio) ";
+pub const COPY_AUTHORS: &str = "INSERT INTO authors (name, bio) ";
 const COPY_AUTHORS_BATCH_SIZE: usize = 32767usize;
 pub async fn copy_authors<'a, E: AsExecutor, I>(
     mut db: E,

--- a/tests/snapshots/codegen__borrowed_one_row_unaffected.snap
+++ b/tests/snapshots/codegen__borrowed_one_row_unaffected.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const GET_AUTHOR_BY_NAME: &str = "SELECT id, name, bio FROM authors WHERE name = $1";
+pub const GET_AUTHOR_BY_NAME: &str = "SELECT id, name, bio FROM authors WHERE name = $1";
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct GetAuthorByNameRow {
     pub id: i64,

--- a/tests/snapshots/codegen__borrowed_params_struct.snap
+++ b/tests/snapshots/codegen__borrowed_params_struct.snap
@@ -48,7 +48,7 @@ pub struct UpdateAuthorParams<'a> {
     pub name: &'a str,
     pub bio: Option<&'a str>,
 }
-const UPDATE_AUTHOR: &str = "UPDATE authors SET name = $1, bio = $2";
+pub const UPDATE_AUTHOR: &str = "UPDATE authors SET name = $1, bio = $2";
 pub async fn update_author<E: AsExecutor>(
     mut db: E,
     arg: UpdateAuthorParams<'_>,

--- a/tests/snapshots/codegen__borrowed_scalar.snap
+++ b/tests/snapshots/codegen__borrowed_scalar.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const DELETE_BY_NAME: &str = "DELETE FROM authors WHERE name = $1";
+pub const DELETE_BY_NAME: &str = "DELETE FROM authors WHERE name = $1";
 pub async fn delete_by_name<E: AsExecutor>(
     mut db: E,
     name: &str,

--- a/tests/snapshots/codegen__borrowed_slice_param.snap
+++ b/tests/snapshots/codegen__borrowed_slice_param.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const DELETE_BY_NAMES: &str = "DELETE FROM authors WHERE name = ANY($1)";
+pub const DELETE_BY_NAMES: &str = "DELETE FROM authors WHERE name = ANY($1)";
 pub async fn delete_by_names<E: AsExecutor>(
     mut db: E,
     names: &[String],

--- a/tests/snapshots/codegen__borrowed_with_custom_owned.snap
+++ b/tests/snapshots/codegen__borrowed_with_custom_owned.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const GET_BY_NAME: &str = "SELECT id, name, bio FROM authors WHERE name = $1";
+pub const GET_BY_NAME: &str = "SELECT id, name, bio FROM authors WHERE name = $1";
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct GetByNameRow {
     pub id: i64,

--- a/tests/snapshots/codegen__copyfrom.snap
+++ b/tests/snapshots/codegen__copyfrom.snap
@@ -48,7 +48,7 @@ pub struct CopyAuthorsParams {
     pub name: String,
     pub bio: Option<String>,
 }
-const COPY_AUTHORS: &str = "INSERT INTO authors (name, bio) ";
+pub const COPY_AUTHORS: &str = "INSERT INTO authors (name, bio) ";
 const COPY_AUTHORS_BATCH_SIZE: usize = 32767usize;
 pub async fn copy_authors<E: AsExecutor, I>(
     mut db: E,

--- a/tests/snapshots/codegen__dynamic_slice_param.snap
+++ b/tests/snapshots/codegen__dynamic_slice_param.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const LIST_AUTHORS_BY_DYNAMIC_IDS: &str = "SELECT id, name, bio FROM authors WHERE id IN ($1)";
+pub const LIST_AUTHORS_BY_DYNAMIC_IDS: &str = "SELECT id, name, bio FROM authors WHERE id IN ($1)";
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct ListAuthorsByDynamicIdsRow {
     pub id: i64,

--- a/tests/snapshots/codegen__embed.snap
+++ b/tests/snapshots/codegen__embed.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const GET_AUTHOR_EMBED: &str = "SELECT a.id, a.name, a.bio FROM authors a WHERE a.id = $1";
+pub const GET_AUTHOR_EMBED: &str = "SELECT a.id, a.name, a.bio FROM authors a WHERE a.id = $1";
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct AuthorsEmbed {
     pub id: i64,

--- a/tests/snapshots/codegen__enum_types.snap
+++ b/tests/snapshots/codegen__enum_types.snap
@@ -53,7 +53,7 @@ pub enum Status {
     #[sqlx(rename = "banned")]
     Banned,
 }
-const GET_USER_STATUS: &str = "SELECT status FROM users WHERE id = $1";
+pub const GET_USER_STATUS: &str = "SELECT status FROM users WHERE id = $1";
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct GetUserStatusRow {
     pub status: Status,

--- a/tests/snapshots/codegen__exec.snap
+++ b/tests/snapshots/codegen__exec.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const DELETE_AUTHOR: &str = "DELETE FROM authors WHERE id = $1";
+pub const DELETE_AUTHOR: &str = "DELETE FROM authors WHERE id = $1";
 pub async fn delete_author<E: AsExecutor>(
     mut db: E,
     id: i64,

--- a/tests/snapshots/codegen__execlastid.snap
+++ b/tests/snapshots/codegen__execlastid.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const CREATE_AUTHOR: &str = "INSERT INTO authors (name) VALUES ($1) RETURNING id";
+pub const CREATE_AUTHOR: &str = "INSERT INTO authors (name) VALUES ($1) RETURNING id";
 pub async fn create_author<E: AsExecutor>(
     mut db: E,
     name: String,

--- a/tests/snapshots/codegen__execresult.snap
+++ b/tests/snapshots/codegen__execresult.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const DELETE_AUTHOR_RESULT: &str = "DELETE FROM authors WHERE id = $1";
+pub const DELETE_AUTHOR_RESULT: &str = "DELETE FROM authors WHERE id = $1";
 pub async fn delete_author_result<E: AsExecutor>(
     mut db: E,
     id: i64,

--- a/tests/snapshots/codegen__execrows.snap
+++ b/tests/snapshots/codegen__execrows.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const DELETE_AUTHOR_ROWS: &str = "DELETE FROM authors WHERE id = $1";
+pub const DELETE_AUTHOR_ROWS: &str = "DELETE FROM authors WHERE id = $1";
 pub async fn delete_author_rows<E: AsExecutor>(
     mut db: E,
     id: i64,

--- a/tests/snapshots/codegen__many.snap
+++ b/tests/snapshots/codegen__many.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const LIST_AUTHORS: &str = "SELECT id, name, bio FROM authors";
+pub const LIST_AUTHORS: &str = "SELECT id, name, bio FROM authors";
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct ListAuthorsRow {
     pub id: i64,

--- a/tests/snapshots/codegen__multidimensional_array_types.snap
+++ b/tests/snapshots/codegen__multidimensional_array_types.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const GET_MATRIX: &str = "SELECT matrix FROM tensors WHERE id = $1";
+pub const GET_MATRIX: &str = "SELECT matrix FROM tensors WHERE id = $1";
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct GetMatrixRow {
     pub matrix: Vec<Vec<i64>>,

--- a/tests/snapshots/codegen__named_params.snap
+++ b/tests/snapshots/codegen__named_params.snap
@@ -48,7 +48,7 @@ pub struct UpdateAuthorNamedParamsParams {
     pub set_name: String,
     pub author_id: i64,
 }
-const UPDATE_AUTHOR_NAMED_PARAMS: &str = "UPDATE authors SET name = $1 WHERE id = $2";
+pub const UPDATE_AUTHOR_NAMED_PARAMS: &str = "UPDATE authors SET name = $1 WHERE id = $2";
 pub async fn update_author_named_params<E: AsExecutor>(
     mut db: E,
     arg: UpdateAuthorNamedParamsParams,

--- a/tests/snapshots/codegen__nullable_named_param.snap
+++ b/tests/snapshots/codegen__nullable_named_param.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const LIST_AUTHORS_BY_OPTIONAL_BIO: &str = "SELECT id, name, bio FROM authors WHERE bio = $1";
+pub const LIST_AUTHORS_BY_OPTIONAL_BIO: &str = "SELECT id, name, bio FROM authors WHERE bio = $1";
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct ListAuthorsByOptionalBioRow {
     pub id: i64,

--- a/tests/snapshots/codegen__one.snap
+++ b/tests/snapshots/codegen__one.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const GET_AUTHOR: &str = "SELECT id, name, bio FROM authors WHERE id = $1";
+pub const GET_AUTHOR: &str = "SELECT id, name, bio FROM authors WHERE id = $1";
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct GetAuthorRow {
     pub id: i64,

--- a/tests/snapshots/codegen__range_types.snap
+++ b/tests/snapshots/codegen__range_types.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const GET_EVENT_WINDOW: &str = "SELECT id, window, flags FROM events WHERE id = $1";
+pub const GET_EVENT_WINDOW: &str = "SELECT id, window, flags FROM events WHERE id = $1";
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct GetEventWindowRow {
     pub id: i64,

--- a/tests/snapshots/codegen__slice_param.snap
+++ b/tests/snapshots/codegen__slice_param.snap
@@ -43,7 +43,7 @@ impl<T: AsExecutor + ?Sized> AsExecutor for &mut T {
         (**self).as_executor()
     }
 }
-const LIST_AUTHORS_BY_IDS: &str = "SELECT id, name, bio FROM authors WHERE id = ANY($1)";
+pub const LIST_AUTHORS_BY_IDS: &str = "SELECT id, name, bio FROM authors WHERE id = ANY($1)";
 #[derive(Debug, Clone, sqlx::FromRow)]
 pub struct ListAuthorsByIdsRow {
     pub id: i64,


### PR DESCRIPTION
## Summary
- Make generated SQL query constants public so callers can reference them directly.
- Update codegen snapshots to reflect the public constants.

## Validation
- `cargo test`