### PR TITLE
ci: make required checks dispatchable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/hk.yml
+++ b/.github/workflows/hk.yml
@@ -7,6 +7,7 @@ on:
       - main
   schedule:
     - cron: "23 7 * * *"
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- allow manual dispatch of the CI workflow that provides `test` and `proto-check`
- allow manual dispatch of the hk workflow that provides `Check`

This lets maintainers prove all protected checks on `main` even when a bot-authored merge suppresses push-triggered workflows.

## Verification

- `mise exec -- hk check --all --slow`
- `mise exec -- cargo test --workspace`
- `mise exec -- cargo build --target wasm32-wasip1`
- `mise exec -- cargo package --locked --allow-dirty`