### PR TITLE
ci: fix main workflow failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,9 +49,6 @@ jobs:
         with:
           targets: wasm32-wasip1
 
-      - name: Cache cargo
-        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
-
       - name: Snapshot tests
         run: cargo test --workspace
         env:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,6 +16,5 @@ jobs:
       - name: Run Release Please
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          token: ${{ secrets.RELEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
## Summary

- remove the Cargo cache step that reports hidden filesystem errors while still returning success
- use the workflow token already granted `contents: write` and `pull-requests: write` instead of the broken release secret

## Verification

- `mise exec -- hk check --all --slow`
- prior full workspace, WASM, package, proto, and PostgreSQL end-to-end gates remain unchanged