### PR TITLE
chore(hk): exclude changelog from checks

### DIFF
--- a/hk.pkl
+++ b/hk.pkl
@@ -4,10 +4,10 @@ import "package://github.com/jdx/hk/releases/download/v1.56.1/hk@1.56.1#/Builtin
 
 min_hk_version = "1.56.1"
 hide_warnings = List("missing-profiles")
+exclude = List("**/CHANGELOG.md")
 
 local generatedFiles =
   List(
-    "**/CHANGELOG.md",
     "**/dist/**",
     "**/gen/**",
     "**/generated/**",


### PR DESCRIPTION
## Summary

- exclude every `CHANGELOG.md` from hk at the root configuration level
- remove the now-redundant changelog entry from the generated-file list

## Verification

- `mise exec -- hk check CHANGELOG.md --why --json` reports all 51 checks skipped with zero matched files
- `mise exec -- hk check --all --slow`