### PR TITLE
fix: declare Rust 1.94 MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,28 @@ permissions:
   contents: read
 
 jobs:
+  msrv:
+    name: Rust 1.94.0
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Install Rust 1.94.0
+        uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable
+        with:
+          toolchain: "1.94.0"
+
+      - name: Check MSRV
+        run: rustup run 1.94.0 cargo check --locked --workspace --all-features --all-targets
+
+      - name: Test MSRV
+        run: rustup run 1.94.0 cargo test --locked -p sqlc-gen-sqlx --all-features --lib --test codegen
+
   test:
     runs-on: ubuntu-latest
     timeout-minutes: 30

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ name = "sqlc-gen-sqlx"
 # - Create a v0.2.x tag
 version = "0.2.3"
 edition = "2024"
+rust-version = "1.94"
 description = "A sqlc plugin that generates type-safe sqlx Rust code from SQL queries."
 repository = "https://github.com/mathematic-inc/sqlc-gen-sqlx"
 license = "MIT OR Apache-2.0"


### PR DESCRIPTION
## Summary
- declare Rust 1.94 as the published crate MSRV
- add an exact Rust 1.94.0 CI job covering the full workspace and all targets
- run the 88 unit and 30 code-generation snapshot tests at the MSRV

## Verification
- Rust 1.94.0 cargo check --locked --workspace --all-features --all-targets
- Rust 1.94.0 cargo test --locked -p sqlc-gen-sqlx --all-features --lib --test codegen (118 passed)
- exhaustive hk check --all --slow