### PR TITLE
fix(ci): harden release workflows and repository checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
           setup_only: true
 
       - name: Install protoc-gen-buffa
-        run: cargo install protoc-gen-buffa@0.9.1 protoc-gen-buffa-packaging@0.9.1
+        run: cargo install --locked protoc-gen-buffa@0.9.1 protoc-gen-buffa-packaging@0.9.1
 
       - name: Verify proto bindings are up to date
         run: |

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,11 +5,14 @@ on:
     branches: [main]
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
+    environment: release
+    permissions:
+      contents: write
+      pull-requests: write
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
           DATABASE_URL: postgres://sqlc:sqlc@localhost:5432/sqlc_test
 
   publish-release:
+    environment: release
     needs: verify
     runs-on: ubuntu-latest
     timeout-minutes: 15

--- a/hk.pkl
+++ b/hk.pkl
@@ -183,8 +183,7 @@ local checks = new Mapping<String, Step> {
   // Rust.
   ["cargo-lockfile"] = new Step {
     glob = List("Cargo.toml", "Cargo.lock", "**/Cargo.toml")
-    check =
-      "worktree=$(mktemp -d) && trap 'rm -rf \"$worktree\"' EXIT && git ls-files -z | tar --null -T - -cf - | tar -xf - -C \"$worktree\" && cargo generate-lockfile --manifest-path \"$worktree/Cargo.toml\" && diff -u Cargo.lock \"$worktree/Cargo.lock\""
+    check = "cargo metadata --locked --format-version 1 --all-features > /dev/null"
     profiles = slow
   }
   ["cargo-fmt"] = (Builtins.cargo_fmt) {


### PR DESCRIPTION
Fix registry-dependent lockfile validation by checking the committed lockfile with cargo metadata --locked. Install the protobuf generators with --locked so their transitive code generator stays consistent with committed bindings. Protect Release Please and GitHub release publishing with the release environment.

Validation: exhaustive local hk checks passed. Rust 1.94.0, Analyze (actions), Check, Analyze (rust), test, proto-check, CodeQL passed at 745b3577fb9c353248d82943104c37628ed75b30; CI includes snapshot tests, a WASM build, PostgreSQL integration tests, and package verification.
